### PR TITLE
cross-platform preprocessing using build.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "tokio",
  "toml",
  "uuid",
+ "walkdir",
  "wgpu",
  "winit",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,19 @@
 [package]
-authors = ["Madeline Sparkles <madeline@mouse.lgbt>", "Mae Rosaline <mae@maestoso.online>"]
+authors = [
+    "Madeline Sparkles <madeline@mouse.lgbt>",
+    "Mae Rosaline <mae@maestoso.online>",
+]
 name = "automancy"
 version = "0.1.0"
 edition = "2021"
-
+build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [profile.release-bin]
 inherits = "release"
-lto = "fat"         # turn on Link-Time Optimizations
-codegen-units = 1   # trade compile time with maximum optimization
-opt-level = "z"     # optimize for size
+lto = "fat"          # turn on Link-Time Optimizations
+codegen-units = 1    # trade compile time with maximum optimization
+opt-level = "z"      # optimize for size
 
 [profile]
 
@@ -19,19 +22,12 @@ dev.lto = "off"
 release.lto = "off"
 
 
-
 [workspace]
-members = [
-    "automancy_defs",
-    "automancy_macros",
-    "automancy_resources"
-]
-
+members = ["automancy_defs", "automancy_macros", "automancy_resources"]
 
 
 [[bin]]
 name = "automancy"
-
 
 
 [workspace.dependencies]
@@ -43,7 +39,10 @@ serde = { version = "1.0", features = ["derive"] }
 
 wgpu = { version = "0.16.3" }
 
-winit = { version = "0.28.6", features = ["x11", "serde"], default-features = false }
+winit = { version = "0.28.6", features = [
+    "x11",
+    "serde",
+], default-features = false }
 
 egui = { version = "0.22.0", default-features = false, features = ["log"] }
 egui-wgpu = { version = "0.22.0" }
@@ -53,8 +52,14 @@ lazy_static = "1.4.0"
 anyhow = "1.0.72"
 thiserror = "1.0.43"
 
-rhai = { git = "https://github.com/rhaiscript/rhai.git", features = ["sync", "no_time", "no_custom_syntax", "no_closure", "no_float", "only_i32"] }
-
+rhai = { git = "https://github.com/rhaiscript/rhai.git", features = [
+    "sync",
+    "no_time",
+    "no_custom_syntax",
+    "no_closure",
+    "no_float",
+    "only_i32",
+] }
 
 
 [dependencies]
@@ -77,7 +82,6 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 
 rhai = { workspace = true }
-
 
 
 automancy_resources = { path = "automancy_resources" }
@@ -106,3 +110,6 @@ futures = "0.3.28"
 ractor = "0.9.0"
 tokio = { version = "1", features = ["full"] }
 rayon = "1.7.0"
+
+[build-dependencies]
+walkdir = "2.3.3"

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,9 @@
 use std::ffi::OsStr;
-use std::fs::{self, metadata};
-use std::io::Read;
+use std::fs::metadata;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str;
-use std::{env, thread};
+use std::thread;
 use walkdir::WalkDir;
 
 fn load_recursively(path: &Path, extension: &OsStr) -> Vec<PathBuf> {

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,113 @@
+use std::ffi::OsStr;
+use std::fs::{self, metadata};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::str;
+use std::{env, thread};
+use walkdir::WalkDir;
+
+fn load_recursively(path: &Path, extension: &OsStr) -> Vec<PathBuf> {
+    WalkDir::new(path)
+        .follow_links(false)
+        .into_iter()
+        .flatten()
+        .filter(|v| v.path().extension() == Some(extension))
+        .map(|v| v.path().to_path_buf())
+        .collect()
+}
+
+fn file_check(path: &Path, out_path: &Path) -> bool {
+    let Ok(in_meta) = metadata(path) else { return true };
+    let Ok(out_meta) = metadata(out_path) else { return true };
+    !out_path.is_file()
+        || in_meta
+            .modified()
+            .and_then(|m| Ok(out_meta.modified()? < m))
+            .unwrap_or(true)
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=resources/");
+    if Command::new("blender").arg("--help").output().is_err() {
+        println!("\n\n==============");
+        println!("Failed to find blender command: please add blender to your PATH.");
+        println!("==============\n\n");
+
+        panic!()
+    }
+
+    // SVG blender runs (parallel)
+    let mut svg_handles = Vec::new();
+    for svg_path in load_recursively(Path::new("resources/"), OsStr::new("svg")) {
+        let out_path = svg_path.with_extension("blend");
+
+        if file_check(&svg_path, &out_path) {
+            svg_handles.push(thread::spawn(move || {
+                let output = Command::new("blender")
+                    .args([
+                        "--background",
+                        "--python-exit-code",
+                        "1",
+                        "--python",
+                        "scripts/export_svg.py",
+                        "--",
+                    ])
+                    .arg(svg_path)
+                    .arg(out_path)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .spawn()
+                    .expect("blender processing couldn't start")
+                    .wait_with_output()
+                    .unwrap();
+                if !output.status.success() {
+                    println!("{}", str::from_utf8(&output.stdout).unwrap());
+                    panic!("Process bad status code")
+                }
+            }));
+        }
+    }
+    for thandle in svg_handles {
+        if thandle.join().is_err() {
+            panic!("Issue with svg to blend");
+        }
+    }
+
+    // Model blender runs (parallel)
+    let mut model_handles = Vec::new();
+    for blend_path in load_recursively(Path::new("resources/"), OsStr::new("blend")) {
+        let out_path = blend_path.with_extension("gltf");
+
+        if file_check(&blend_path, &out_path) {
+            model_handles.push(thread::spawn(move || {
+                let output = Command::new("blender")
+                    .arg(blend_path)
+                    .args([
+                        "--background",
+                        "--python-exit-code",
+                        "1",
+                        "--python",
+                        "scripts/export_blender.py",
+                        "--",
+                    ])
+                    .arg(out_path)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .spawn()
+                    .expect("blender processing couldn't start")
+                    .wait_with_output()
+                    .unwrap();
+                if !output.status.success() {
+                    println!("{}", str::from_utf8(&output.stdout).unwrap());
+                    panic!("Process bad status code")
+                }
+            }));
+        }
+    }
+    for thandle in model_handles {
+        if thandle.join().is_err() {
+            panic!("Issue with model exports");
+        }
+    }
+}

--- a/scripts/export_svg.py
+++ b/scripts/export_svg.py
@@ -2,10 +2,6 @@ import bmesh
 import bpy
 import sys
 import xml.etree.ElementTree as ET
-
-from frozendict import frozendict
-
-
 def main():
     src = sys.argv[-2]
     print(src)
@@ -19,7 +15,7 @@ def main():
     root = tree.getroot()
 
     paths = [tuple([path.attrib['id'],
-                    frozendict(map(lambda x: tuple(x.split(':')), path.attrib['style'].split(';')))
+                    dict(map(lambda x: tuple(x.split(':')), path.attrib['style'].split(';')))
                     ])
              for path in root.iter('{http://www.w3.org/2000/svg}path')]
     total = float(len(paths))


### PR DESCRIPTION
This PR moves the blender preprocessing logic from the bash scripts to build.rs

it doesn't yet remove the bash scripts as i have not tested it on linux. it also only moves the svg and model parts, none of the unused one.

it retains the parallelisation for svg builds and model builds.

i had to remove frozendict from the python script, as it doesn't come preinstalled with blender. i dont see a reason a normal dict shouldn't work.